### PR TITLE
Do not import pylab globally

### DIFF
--- a/rogues/utils/cpltaxes.py
+++ b/rogues/utils/cpltaxes.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pylab as plt
 
 
 def cpltaxes(zz):
@@ -40,6 +39,7 @@ def cpltaxes(zz):
         xmin = xmid - (ymax - ymin) / 2.
         xmax = xmid + (ymax - ymin) / 2.
 
+    import pylab as plt
     plt.axis('equal')
 
     # Scale ranges by 1+2*alpha to give extra space around edges of plot.

--- a/rogues/utils/ps.py
+++ b/rogues/utils/ps.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pylab as plt
 from rogues.utils import cpltaxes
 
 
@@ -47,6 +46,7 @@ def ps(a, m=None, tol=1e-3, rl=0, marksize=0):
     if m == 0:
         e, v = np.linalg.eig(a)
         ax = cpltaxes(e)
+        import pylab as plt
         plt.plot(e.real, e.imag, 'rx')
         plt.axis(ax)
         plt.axis('equal')


### PR DESCRIPTION
Otherwise rogues will fail to import if pylab is not installed (it
should be an optional dependence, not required to import rogues).
