### PR TITLE
Remove use of pylab.hold

### DIFF
--- a/rogues/utils/fv.py
+++ b/rogues/utils/fv.py
@@ -111,10 +111,8 @@ def fv(b, nk=1, thmax=16, do_plot=True):
         plt.plot(f.real, f.imag, 'o')
         plt.axis(ax)
         plt.axis('equal')
-        plt.hold(True)
         # Plot the eigenvalues too.
         plt.plot(e.real, e.imag, 'x')
-        plt.hold(False)
 
     plt.show()
     return f, e

--- a/rogues/utils/gersh.py
+++ b/rogues/utils/gersh.py
@@ -38,12 +38,10 @@ def gersh(A, plot=True):
         ax = cpltaxes(G[:], plt)
         for j in range(n):
             plt.plot(G[:, j].real, G[:, j].imag, '-')      # Plot the disks.
-            plt.hold(True)
 
         plt.plot(e.real, e.imag, 'x')    # Plot the eigenvalues too.
         plt.axis(ax)
         plt.axis('equal')
-        plt.hold(False)
         plt.show()
 
     return G, e

--- a/rogues/utils/ps.py
+++ b/rogues/utils/ps.py
@@ -97,11 +97,9 @@ def ps(a, m=None, tol=1e-3, rl=0, marksize=0):
             # the pseudo eigenvalues so we punt an put in a default
             marksize = 5
 
-        plt.hold(True)
         e, v = np.linalg.eig(a)
         plt.plot(e.real, e.imag, 'rx')
         plt.setp(h, 'markersize', marksize)
-        plt.hold(False)
         plt.show()
 
     else:

--- a/rogues/utils/pscont.py
+++ b/rogues/utils/pscont.py
@@ -99,22 +99,17 @@ def pscont(a, k=0, npts=None, ax=None, levels=None):
 
     if k == 0 or k == 1:
         plt.pcolor(x, y, z)
-        plt.hold(True)
     elif k == 2 or k == 3:
         fig = plt.figure()
-        plt.hold(True)
         ax = fig.gca(projection='3d')
         surf = ax.plot_surface(x, y, z, rstride=1, cstride=1,
                                cmap=cm.coolwarm, linewidth=.2,
                                antialiased=True)
-        plt.hold(True)
 
     if k == 0:
         plt.contour(x, y, z, levels)
-        plt.hold(True)
     elif k == 4:
         plt.contour(x, y, z, levels)
-        plt.hold(True)
 
     if k != 2 and k != 3:
         if k == 0 or k == 1:
@@ -124,6 +119,5 @@ def pscont(a, k=0, npts=None, ax=None, levels=None):
         plt.plot(e.real, e.imag, ''.join((s, 'x')))
 
     plt.axis('equal')
-    plt.hold(False)
     plt.show()
     return x, y, z


### PR DESCRIPTION
pylab.hold(True) has always been the default, has been deprecated
since matplotlib 2.1 and was removed in 3.0, yielding

  AttributeError: module 'matplotlib.pylab' has no attribute 'hold'

Instead of pylab.hold(False), one should create a new
figure (automatic in some environments, such as in a new Jupyter
cell).  Further discussion:

  https://github.com/matplotlib/matplotlib/issues/12337/